### PR TITLE
Fix #6 `onProgramUpdate` error by refactoring to VersionedTransaction

### DIFF
--- a/src/examples/backrun/utils.ts
+++ b/src/examples/backrun/utils.ts
@@ -33,7 +33,7 @@ export const onAccountUpdates = async (
       const bundles = transactions.map(tx => {
         const b = new Bundle([tx], bundleTransactionLimit);
 
-        let maybeBundle = b.addSignedTransactions(
+        let maybeBundle = b.addTransactions(
           buildMemoTransaction(keypair, resp.blockhash)
         );
         if (isError(maybeBundle)) {

--- a/src/sdk/block-engine/searcher.ts
+++ b/src/sdk/block-engine/searcher.ts
@@ -1,4 +1,4 @@
-import {Keypair, PublicKey, Transaction} from '@solana/web3.js';
+import {Keypair, PublicKey, VersionedTransaction} from '@solana/web3.js';
 import {
   ChannelCredentials,
   ClientReadableStream,
@@ -104,7 +104,7 @@ export class SearcherClient {
   // Triggers the provided callback on account updates owned by the provided list of programs.
   onProgramUpdate(
     programs: PublicKey[],
-    successCallback: (transactions: Transaction[]) => void,
+    successCallback: (transactions: VersionedTransaction[]) => void,
     errorCallback: (e: Error) => void
   ) {
     const stream: ClientReadableStream<PendingTxNotification> =
@@ -128,7 +128,7 @@ export class SearcherClient {
   // Triggers the provided callback on updates to the provided accounts.
   onAccountUpdate(
     accounts: PublicKey[],
-    successCallback: (transactions: Transaction[]) => void,
+    successCallback: (transactions: VersionedTransaction[]) => void,
     errorCallback: (e: Error) => void
   ) {
     const stream: ClientReadableStream<PendingTxNotification> =

--- a/src/sdk/block-engine/types.ts
+++ b/src/sdk/block-engine/types.ts
@@ -1,4 +1,10 @@
-import {Keypair, PublicKey, SystemProgram, Transaction} from '@solana/web3.js';
+import {
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  TransactionMessage,
+  VersionedTransaction,
+} from '@solana/web3.js';
 
 import {Bundle as IBundle} from '../../gen/block-engine/bundle';
 import {Header} from '../../gen/block-engine/shared';
@@ -7,31 +13,28 @@ import {serializeTransactions} from './utils';
 
 // Represents a bundle of transactions expected to execute all or nothing, atomically and sequentially.
 export class Bundle implements IBundle {
-  private transactions: Transaction[];
+  private transactions: VersionedTransaction[];
   // Maximum number of transactions a bundle may have.
   private readonly transactionLimit: number;
   header: Header | undefined;
   packets: Packet[];
 
-  constructor(txs: Transaction[], transactionLimit: number) {
+  constructor(txs: VersionedTransaction[], transactionLimit: number) {
     this.transactions = txs;
     this.transactionLimit = transactionLimit;
     this.packets = serializeTransactions(txs);
   }
 
   // Adds signed transactions to the bundle. Filters out any txs failing signature verification.
-  addSignedTransactions(...signedTransactions: Transaction[]): Bundle | Error {
+  addSignedTransactions(
+    ...signedTransactions: VersionedTransaction[]
+  ): Bundle | Error {
     const numTransactions =
       this.transactions.length + signedTransactions.length;
     if (numTransactions > this.transactionLimit) {
       return new Error(
         `${numTransactions} exceeds transaction limit of ${this.transactionLimit}`
       );
-    }
-
-    // TODO: Is this expensive?
-    if (this.transactions.some(tx => !tx.verifySignatures())) {
-      return new Error('Some transaction failed signature verification');
     }
 
     this.transactions.push(...signedTransactions);
@@ -42,14 +45,12 @@ export class Bundle implements IBundle {
     return this;
   }
 
-  // Attaches a tip instruction to an existing transaction if provided otherwise creates a new transaction to tip.
-  attachTip(
+  // Creates a new transaction to tip.
+  addTipTx(
     keypair: Keypair,
     tipLamports: number,
     tipAccount: PublicKey,
-    recentBlockhash: string,
-    lastValidBlockHeight: number,
-    tx?: Transaction
+    recentBlockhash: string
   ): Bundle | Error {
     const numTransactions = this.transactions.length + 1;
     if (numTransactions > this.transactionLimit) {
@@ -64,21 +65,17 @@ export class Bundle implements IBundle {
       lamports: tipLamports,
     });
 
-    let tipTx;
-    if (!tx) {
-      tipTx = new Transaction();
-    } else {
-      tipTx = tx;
-    }
+    const instructions = [tipIx];
 
-    tipTx.add(tipIx);
-    tipTx.recentBlockhash = recentBlockhash;
-    tipTx.lastValidBlockHeight = lastValidBlockHeight;
+    const messageV0 = new TransactionMessage({
+      payerKey: keypair.publicKey,
+      recentBlockhash: recentBlockhash,
+      instructions,
+    }).compileToV0Message();
 
-    tipTx.sign({
-      publicKey: keypair.publicKey,
-      secretKey: keypair.secretKey,
-    });
+    const tipTx = new VersionedTransaction(messageV0);
+
+    tipTx.sign([keypair]);
 
     this.transactions.push(tipTx);
     this.packets = this.packets.concat(serializeTransactions([tipTx]));

--- a/src/sdk/block-engine/types.ts
+++ b/src/sdk/block-engine/types.ts
@@ -25,22 +25,17 @@ export class Bundle implements IBundle {
     this.packets = serializeTransactions(txs);
   }
 
-  // Adds signed transactions to the bundle. Filters out any txs failing signature verification.
-  addSignedTransactions(
-    ...signedTransactions: VersionedTransaction[]
-  ): Bundle | Error {
-    const numTransactions =
-      this.transactions.length + signedTransactions.length;
+  // Adds transactions to the bundle.
+  addTransactions(...transactions: VersionedTransaction[]): Bundle | Error {
+    const numTransactions = this.transactions.length + transactions.length;
     if (numTransactions > this.transactionLimit) {
       return new Error(
         `${numTransactions} exceeds transaction limit of ${this.transactionLimit}`
       );
     }
 
-    this.transactions.push(...signedTransactions);
-    this.packets = this.packets.concat(
-      serializeTransactions(signedTransactions)
-    );
+    this.transactions.push(...transactions);
+    this.packets = this.packets.concat(serializeTransactions(transactions));
 
     return this;
   }

--- a/src/sdk/block-engine/utils.ts
+++ b/src/sdk/block-engine/utils.ts
@@ -1,4 +1,4 @@
-import {Transaction} from '@solana/web3.js';
+import {VersionedTransaction} from '@solana/web3.js';
 
 import {Meta, Packet} from '../../gen/block-engine/packet';
 
@@ -6,18 +6,19 @@ export const unixTimestampFromDate = (date: Date) => {
   return Math.floor(date.getTime() / 1000);
 };
 
-export const deserializeTransactions = (packets: Packet[]): Transaction[] => {
+export const deserializeTransactions = (
+  packets: Packet[]
+): VersionedTransaction[] => {
   return packets.map(p => {
-    return Transaction.from(p.data);
+    return VersionedTransaction.deserialize(p.data);
   });
 };
 
-export const serializeTransactions = (txs: Transaction[]): Packet[] => {
+export const serializeTransactions = (
+  txs: VersionedTransaction[]
+): Packet[] => {
   return txs.map(tx => {
-    const data = tx.serialize({
-      requireAllSignatures: true,
-      verifySignatures: true,
-    });
+    const data = tx.serialize();
 
     return {
       data,


### PR DESCRIPTION
- replaced uses of `Transaction` with `VersionedTransaction`
- refactored `addSignedTransactions` to `addTransactions` because Versioned transaction doesnt have the `verifySignatures` function anymore. I am not sure why this check was strictly necessary so i just removed it instead of finding a way to workaround
- refactored `attachTip` to `addTipTx`. i couldn't see why retaining the add tip ixn to existing txn was strictly necessary so i just removed it. otherwise, the function would become more complicated because signing works a little bit differently with versioned transactions. to properly support adding a tip txn to a existing transaction we would need a field for instruction and a field for signers.
From https://docs.solana.com/developing/versioned-transactions:
> NOTE: After calling the transaction.sign() method, all the previous transaction signatures will be fully replaced by new signatures created from the provided in Signers.

I have not tested the examples.
I am using this branch in my bot and it seems to fix successfully #6
