### PR TITLE
add async generators functions to subscribe to updates

### DIFF
--- a/src/examples/backrun/utils.ts
+++ b/src/examples/backrun/utils.ts
@@ -2,8 +2,9 @@ import {
   Connection,
   Keypair,
   PublicKey,
-  Transaction,
   TransactionInstruction,
+  TransactionMessage,
+  VersionedTransaction,
 } from '@solana/web3.js';
 
 import {SearcherClient} from '../../sdk/block-engine/searcher';
@@ -24,7 +25,7 @@ export const onAccountUpdates = async (
   const tipAccount = new PublicKey(_tipAccount);
   c.onAccountUpdate(
     accounts,
-    async (transactions: Transaction[]) => {
+    async (transactions: VersionedTransaction[]) => {
       console.log(`received ${transactions.length} transactions`);
 
       const resp = await conn.getLatestBlockhash('processed');
@@ -32,23 +33,18 @@ export const onAccountUpdates = async (
       const bundles = transactions.map(tx => {
         const b = new Bundle([tx], bundleTransactionLimit);
 
-        let maybeBundle = b.addSignedTransactions(
-          buildMemoTransaction(
-            keypair,
-            resp.blockhash,
-            resp.lastValidBlockHeight
-          )
+        let maybeBundle = b.addTransactions(
+          buildMemoTransaction(keypair, resp.blockhash)
         );
         if (isError(maybeBundle)) {
           throw maybeBundle;
         }
 
-        maybeBundle = maybeBundle.attachTip(
+        maybeBundle = maybeBundle.addTipTx(
           keypair,
           100_000_000,
           tipAccount,
-          resp.blockhash,
-          resp.lastValidBlockHeight
+          resp.blockhash
         );
 
         if (isError(maybeBundle)) {
@@ -86,9 +82,8 @@ export const onBundleResult = (c: SearcherClient) => {
 
 const buildMemoTransaction = (
   keypair: Keypair,
-  recentBlockhash: string,
-  lastValidBlockHeight: number
-): Transaction => {
+  recentBlockhash: string
+): VersionedTransaction => {
   const ix = new TransactionInstruction({
     keys: [
       {
@@ -101,15 +96,17 @@ const buildMemoTransaction = (
     data: Buffer.from('Jito Backrun'),
   });
 
-  const tx = new Transaction();
-  tx.recentBlockhash = recentBlockhash;
-  tx.lastValidBlockHeight = lastValidBlockHeight;
+  const instructions = [ix];
 
-  tx.add(ix);
-  tx.sign({
-    publicKey: keypair.publicKey,
-    secretKey: keypair.secretKey,
-  });
+  const messageV0 = new TransactionMessage({
+    payerKey: keypair.publicKey,
+    recentBlockhash: recentBlockhash,
+    instructions,
+  }).compileToV0Message();
+
+  const tx = new VersionedTransaction(messageV0);
+
+  tx.sign([keypair]);
 
   return tx;
 };

--- a/src/sdk/block-engine/searcher.ts
+++ b/src/sdk/block-engine/searcher.ts
@@ -226,7 +226,7 @@ export class SearcherClient {
     });
   }
 
-  // Yields on updates to the provided accounts.
+  // Yields on bundle results.
   async *bundleResults(
     onError: (e: Error) => void
   ): AsyncGenerator<BundleResult> {

--- a/src/sdk/block-engine/searcher.ts
+++ b/src/sdk/block-engine/searcher.ts
@@ -1,4 +1,4 @@
-import {Keypair, PublicKey, Transaction} from '@solana/web3.js';
+import {Keypair, PublicKey, VersionedTransaction} from '@solana/web3.js';
 import {
   ChannelCredentials,
   ClientReadableStream,
@@ -104,7 +104,7 @@ export class SearcherClient {
   // Triggers the provided callback on account updates owned by the provided list of programs.
   onProgramUpdate(
     programs: PublicKey[],
-    successCallback: (transactions: Transaction[]) => void,
+    successCallback: (transactions: VersionedTransaction[]) => void,
     errorCallback: (e: Error) => void
   ) {
     const stream: ClientReadableStream<PendingTxNotification> =
@@ -128,7 +128,7 @@ export class SearcherClient {
   // Triggers the provided callback on updates to the provided accounts.
   onAccountUpdate(
     accounts: PublicKey[],
-    successCallback: (transactions: Transaction[]) => void,
+    successCallback: (transactions: VersionedTransaction[]) => void,
     errorCallback: (e: Error) => void
   ) {
     const stream: ClientReadableStream<PendingTxNotification> =

--- a/src/sdk/block-engine/types.ts
+++ b/src/sdk/block-engine/types.ts
@@ -1,4 +1,10 @@
-import {Keypair, PublicKey, SystemProgram, Transaction} from '@solana/web3.js';
+import {
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  TransactionMessage,
+  VersionedTransaction,
+} from '@solana/web3.js';
 
 import {Bundle as IBundle} from '../../gen/block-engine/bundle';
 import {Header} from '../../gen/block-engine/shared';
@@ -7,49 +13,39 @@ import {serializeTransactions} from './utils';
 
 // Represents a bundle of transactions expected to execute all or nothing, atomically and sequentially.
 export class Bundle implements IBundle {
-  private transactions: Transaction[];
+  private transactions: VersionedTransaction[];
   // Maximum number of transactions a bundle may have.
   private readonly transactionLimit: number;
   header: Header | undefined;
   packets: Packet[];
 
-  constructor(txs: Transaction[], transactionLimit: number) {
+  constructor(txs: VersionedTransaction[], transactionLimit: number) {
     this.transactions = txs;
     this.transactionLimit = transactionLimit;
     this.packets = serializeTransactions(txs);
   }
 
-  // Adds signed transactions to the bundle. Filters out any txs failing signature verification.
-  addSignedTransactions(...signedTransactions: Transaction[]): Bundle | Error {
-    const numTransactions =
-      this.transactions.length + signedTransactions.length;
+  // Adds transactions to the bundle.
+  addTransactions(...transactions: VersionedTransaction[]): Bundle | Error {
+    const numTransactions = this.transactions.length + transactions.length;
     if (numTransactions > this.transactionLimit) {
       return new Error(
         `${numTransactions} exceeds transaction limit of ${this.transactionLimit}`
       );
     }
 
-    // TODO: Is this expensive?
-    if (this.transactions.some(tx => !tx.verifySignatures())) {
-      return new Error('Some transaction failed signature verification');
-    }
-
-    this.transactions.push(...signedTransactions);
-    this.packets = this.packets.concat(
-      serializeTransactions(signedTransactions)
-    );
+    this.transactions.push(...transactions);
+    this.packets = this.packets.concat(serializeTransactions(transactions));
 
     return this;
   }
 
-  // Attaches a tip instruction to an existing transaction if provided otherwise creates a new transaction to tip.
-  attachTip(
+  // Creates a new transaction to tip.
+  addTipTx(
     keypair: Keypair,
     tipLamports: number,
     tipAccount: PublicKey,
-    recentBlockhash: string,
-    lastValidBlockHeight: number,
-    tx?: Transaction
+    recentBlockhash: string
   ): Bundle | Error {
     const numTransactions = this.transactions.length + 1;
     if (numTransactions > this.transactionLimit) {
@@ -64,21 +60,17 @@ export class Bundle implements IBundle {
       lamports: tipLamports,
     });
 
-    let tipTx;
-    if (!tx) {
-      tipTx = new Transaction();
-    } else {
-      tipTx = tx;
-    }
+    const instructions = [tipIx];
 
-    tipTx.add(tipIx);
-    tipTx.recentBlockhash = recentBlockhash;
-    tipTx.lastValidBlockHeight = lastValidBlockHeight;
+    const messageV0 = new TransactionMessage({
+      payerKey: keypair.publicKey,
+      recentBlockhash: recentBlockhash,
+      instructions,
+    }).compileToV0Message();
 
-    tipTx.sign({
-      publicKey: keypair.publicKey,
-      secretKey: keypair.secretKey,
-    });
+    const tipTx = new VersionedTransaction(messageV0);
+
+    tipTx.sign([keypair]);
 
     this.transactions.push(tipTx);
     this.packets = this.packets.concat(serializeTransactions([tipTx]));

--- a/src/sdk/block-engine/utils.ts
+++ b/src/sdk/block-engine/utils.ts
@@ -1,4 +1,4 @@
-import {Transaction} from '@solana/web3.js';
+import {VersionedTransaction} from '@solana/web3.js';
 
 import {Meta, Packet} from '../../gen/block-engine/packet';
 
@@ -6,18 +6,19 @@ export const unixTimestampFromDate = (date: Date) => {
   return Math.floor(date.getTime() / 1000);
 };
 
-export const deserializeTransactions = (packets: Packet[]): Transaction[] => {
+export const deserializeTransactions = (
+  packets: Packet[]
+): VersionedTransaction[] => {
   return packets.map(p => {
-    return Transaction.from(p.data);
+    return VersionedTransaction.deserialize(p.data);
   });
 };
 
-export const serializeTransactions = (txs: Transaction[]): Packet[] => {
+export const serializeTransactions = (
+  txs: VersionedTransaction[]
+): Packet[] => {
   return txs.map(tx => {
-    const data = tx.serialize({
-      requireAllSignatures: true,
-      verifySignatures: true,
-    });
+    const data = tx.serialize();
 
     return {
       data,


### PR DESCRIPTION
having to rely on callbacks can be a pita and is not considered good practice.

- added `programUpdates`, `accountUpdates` and `bundleResults` functions that follow the async generator pattern