### PR TITLE
add rpc `simulateBundle`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Jito Team <team@jito.wtf>",
   "license": "Apache-2.0",
   "name": "jito-ts",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "prepublish": "tsc",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Jito Team <team@jito.wtf>",
   "license": "Apache-2.0",
   "name": "jito-ts",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "prepublish": "tsc",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Jito Team <team@jito.wtf>",
   "license": "Apache-2.0",
   "name": "jito-ts",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "prepublish": "tsc",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,12 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.8.7",
     "@noble/ed25519": "^1.7.1",
-    "@solana/web3.js": "^1.73.0",
-    "dotenv": "^16.0.3"
+    "@solana/web3.js": "^1.74.0",
+    "agentkeepalive": "^4.3.0",
+    "dotenv": "^16.0.3",
+    "jayson": "^4.0.0",
+    "node-fetch": "^3.3.1",
+    "superstruct": "^1.0.3"
   },
   "devDependencies": {
     "@types/google-protobuf": "^3.15.6",

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
     "agentkeepalive": "^4.3.0",
     "dotenv": "^16.0.3",
     "jayson": "^4.0.0",
-    "node-fetch": "^3.3.1",
+    "node-fetch": "^2.6.7",
     "superstruct": "^1.0.3"
   },
   "devDependencies": {
     "@types/google-protobuf": "^3.15.6",
     "@types/node": "^14.11.2",
-    "@types/node-fetch": "^2.6.2",
+    "@types/node-fetch": "^2.6",
     "grpc-tools": "^1.12.3",
     "gts": "^3.1.1",
     "protoc-gen-ts": "^0.8.5",

--- a/scripts/gen-block-engine-protos
+++ b/scripts/gen-block-engine-protos
@@ -14,4 +14,5 @@ protoc \
   --proto_path="${PROTOS_PATH}" \
   --ts_proto_out=${OUT_DIR} \
   --ts_proto_opt=outputServices=grpc-js \
+  --ts_proto_opt=esModuleInterop=true \
   auth.proto block.proto block_engine.proto bundle.proto packet.proto relayer.proto searcher.proto shared.proto shredstream.proto

--- a/scripts/gen-geyser-protos
+++ b/scripts/gen-geyser-protos
@@ -14,4 +14,5 @@ protoc \
   --proto_path="${PROTOS_PATH}" \
   --ts_proto_out=${OUT_DIR} \
   --ts_proto_opt=outputServices=grpc-js \
+  --ts_proto_opt=esModuleInterop=true \
   confirmed_block.proto geyser.proto transaction_by_addr.proto

--- a/src/examples/backrun/index.ts
+++ b/src/examples/backrun/index.ts
@@ -31,13 +31,7 @@ const main = async () => {
   console.log('RPC_URL:', rpcUrl);
   const conn = new Connection(rpcUrl, 'confirmed');
 
-  await onAccountUpdates(
-    c,
-    accounts,
-    bundleTransactionLimit,
-    keypair,
-    conn
-  );
+  await onAccountUpdates(c, accounts, bundleTransactionLimit, keypair, conn);
   onBundleResult(c);
 };
 

--- a/src/examples/backrun/utils.ts
+++ b/src/examples/backrun/utils.ts
@@ -63,8 +63,7 @@ export const onAccountUpdates = async (
           const resp = await c.sendBundle(b);
           console.log('resp:', resp);
         } catch (e) {
-          console.error('error:', e);
-          throw e;
+          console.error('error sending bundle:', e);
         }
       });
     },

--- a/src/gen/block-engine/auth.ts
+++ b/src/gen/block-engine/auth.ts
@@ -11,7 +11,7 @@ import {
   ServiceError,
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";
-import * as _m0 from "protobufjs/minimal";
+import _m0 from "protobufjs/minimal";
 import { Timestamp } from "./google/protobuf/timestamp";
 
 export const protobufPackage = "auth";

--- a/src/gen/block-engine/block.ts
+++ b/src/gen/block-engine/block.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
-import * as Long from "long";
-import * as _m0 from "protobufjs/minimal";
+import Long from "long";
+import _m0 from "protobufjs/minimal";
 import { Header } from "./shared";
 
 export const protobufPackage = "block";
@@ -203,8 +203,6 @@ function longToNumber(long: Long): number {
   return long.toNumber();
 }
 
-// If you get a compile-error about 'Constructor<Long> and ... have no overlap',
-// add '--ts_proto_opt=esModuleInterop=true' as a flag when calling 'protoc'.
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;
   _m0.configure();

--- a/src/gen/block-engine/block_engine.ts
+++ b/src/gen/block-engine/block_engine.ts
@@ -15,8 +15,8 @@ import {
   ServiceError,
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";
-import * as Long from "long";
-import * as _m0 from "protobufjs/minimal";
+import Long from "long";
+import _m0 from "protobufjs/minimal";
 import { BundleUuid } from "./bundle";
 import { PacketBatch } from "./packet";
 import { Header, Heartbeat } from "./shared";
@@ -1118,8 +1118,6 @@ function longToNumber(long: Long): number {
   return long.toNumber();
 }
 
-// If you get a compile-error about 'Constructor<Long> and ... have no overlap',
-// add '--ts_proto_opt=esModuleInterop=true' as a flag when calling 'protoc'.
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;
   _m0.configure();

--- a/src/gen/block-engine/bundle.ts
+++ b/src/gen/block-engine/bundle.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
-import * as Long from "long";
-import * as _m0 from "protobufjs/minimal";
+import Long from "long";
+import _m0 from "protobufjs/minimal";
 import { Packet } from "./packet";
 import { Header } from "./shared";
 
@@ -814,8 +814,6 @@ function longToNumber(long: Long): number {
   return long.toNumber();
 }
 
-// If you get a compile-error about 'Constructor<Long> and ... have no overlap',
-// add '--ts_proto_opt=esModuleInterop=true' as a flag when calling 'protoc'.
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;
   _m0.configure();

--- a/src/gen/block-engine/google/protobuf/timestamp.ts
+++ b/src/gen/block-engine/google/protobuf/timestamp.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
-import * as Long from "long";
-import * as _m0 from "protobufjs/minimal";
+import Long from "long";
+import _m0 from "protobufjs/minimal";
 
 export const protobufPackage = "google.protobuf";
 
@@ -210,8 +210,6 @@ function longToNumber(long: Long): number {
   return long.toNumber();
 }
 
-// If you get a compile-error about 'Constructor<Long> and ... have no overlap',
-// add '--ts_proto_opt=esModuleInterop=true' as a flag when calling 'protoc'.
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;
   _m0.configure();

--- a/src/gen/block-engine/packet.ts
+++ b/src/gen/block-engine/packet.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
-import * as Long from "long";
-import * as _m0 from "protobufjs/minimal";
+import Long from "long";
+import _m0 from "protobufjs/minimal";
 
 export const protobufPackage = "packet";
 
@@ -389,8 +389,6 @@ function longToNumber(long: Long): number {
   return long.toNumber();
 }
 
-// If you get a compile-error about 'Constructor<Long> and ... have no overlap',
-// add '--ts_proto_opt=esModuleInterop=true' as a flag when calling 'protoc'.
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;
   _m0.configure();

--- a/src/gen/block-engine/relayer.ts
+++ b/src/gen/block-engine/relayer.ts
@@ -13,7 +13,7 @@ import {
   ServiceError,
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";
-import * as _m0 from "protobufjs/minimal";
+import _m0 from "protobufjs/minimal";
 import { PacketBatch } from "./packet";
 import { Header, Heartbeat, Socket } from "./shared";
 

--- a/src/gen/block-engine/searcher.ts
+++ b/src/gen/block-engine/searcher.ts
@@ -13,8 +13,8 @@ import {
   ServiceError,
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";
-import * as Long from "long";
-import * as _m0 from "protobufjs/minimal";
+import Long from "long";
+import _m0 from "protobufjs/minimal";
 import { Bundle, BundleResult } from "./bundle";
 import { Timestamp } from "./google/protobuf/timestamp";
 import { Packet } from "./packet";
@@ -1303,8 +1303,6 @@ function longToNumber(long: Long): number {
   return long.toNumber();
 }
 
-// If you get a compile-error about 'Constructor<Long> and ... have no overlap',
-// add '--ts_proto_opt=esModuleInterop=true' as a flag when calling 'protoc'.
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;
   _m0.configure();

--- a/src/gen/block-engine/shared.ts
+++ b/src/gen/block-engine/shared.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
-import * as Long from "long";
-import * as _m0 from "protobufjs/minimal";
+import Long from "long";
+import _m0 from "protobufjs/minimal";
 import { Timestamp } from "./google/protobuf/timestamp";
 
 export const protobufPackage = "shared";
@@ -238,8 +238,6 @@ function longToNumber(long: Long): number {
   return long.toNumber();
 }
 
-// If you get a compile-error about 'Constructor<Long> and ... have no overlap',
-// add '--ts_proto_opt=esModuleInterop=true' as a flag when calling 'protoc'.
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;
   _m0.configure();

--- a/src/gen/block-engine/shredstream.ts
+++ b/src/gen/block-engine/shredstream.ts
@@ -11,7 +11,7 @@ import {
   ServiceError,
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";
-import * as _m0 from "protobufjs/minimal";
+import _m0 from "protobufjs/minimal";
 import { Socket } from "./shared";
 
 export const protobufPackage = "shredstream";

--- a/src/gen/geyser/confirmed_block.ts
+++ b/src/gen/geyser/confirmed_block.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
-import * as Long from "long";
-import * as _m0 from "protobufjs/minimal";
+import Long from "long";
+import _m0 from "protobufjs/minimal";
 
 export const protobufPackage = "solana.storage.ConfirmedBlock";
 
@@ -1739,8 +1739,6 @@ function longToNumber(long: Long): number {
   return long.toNumber();
 }
 
-// If you get a compile-error about 'Constructor<Long> and ... have no overlap',
-// add '--ts_proto_opt=esModuleInterop=true' as a flag when calling 'protoc'.
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;
   _m0.configure();

--- a/src/gen/geyser/geyser.ts
+++ b/src/gen/geyser/geyser.ts
@@ -13,8 +13,8 @@ import {
   ServiceError,
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";
-import * as Long from "long";
-import * as _m0 from "protobufjs/minimal";
+import Long from "long";
+import _m0 from "protobufjs/minimal";
 import { ConfirmedTransaction, Reward } from "./confirmed_block";
 import { Timestamp } from "./google/protobuf/timestamp";
 
@@ -1821,8 +1821,6 @@ function longToNumber(long: Long): number {
   return long.toNumber();
 }
 
-// If you get a compile-error about 'Constructor<Long> and ... have no overlap',
-// add '--ts_proto_opt=esModuleInterop=true' as a flag when calling 'protoc'.
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;
   _m0.configure();

--- a/src/gen/geyser/google/protobuf/timestamp.ts
+++ b/src/gen/geyser/google/protobuf/timestamp.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
-import * as Long from "long";
-import * as _m0 from "protobufjs/minimal";
+import Long from "long";
+import _m0 from "protobufjs/minimal";
 
 export const protobufPackage = "google.protobuf";
 
@@ -210,8 +210,6 @@ function longToNumber(long: Long): number {
   return long.toNumber();
 }
 
-// If you get a compile-error about 'Constructor<Long> and ... have no overlap',
-// add '--ts_proto_opt=esModuleInterop=true' as a flag when calling 'protoc'.
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;
   _m0.configure();

--- a/src/gen/geyser/transaction_by_addr.ts
+++ b/src/gen/geyser/transaction_by_addr.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
-import * as Long from "long";
-import * as _m0 from "protobufjs/minimal";
+import Long from "long";
+import _m0 from "protobufjs/minimal";
 
 export const protobufPackage = "solana.storage.TransactionByAddr";
 
@@ -1178,8 +1178,6 @@ function longToNumber(long: Long): number {
   return long.toNumber();
 }
 
-// If you get a compile-error about 'Constructor<Long> and ... have no overlap',
-// add '--ts_proto_opt=esModuleInterop=true' as a flag when calling 'protoc'.
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;
   _m0.configure();

--- a/src/sdk/block-engine/searcher.ts
+++ b/src/sdk/block-engine/searcher.ts
@@ -12,7 +12,6 @@ import {
   GetTipAccountsResponse,
   NextScheduledLeaderResponse,
   PendingTxNotification,
-  PendingTxSubscriptionRequest,
   SearcherServiceClient,
   SendBundleRequest,
   SendBundleResponse,
@@ -111,8 +110,8 @@ export class SearcherClient {
     const stream: ClientReadableStream<PendingTxNotification> =
       this.client.subscribeMempool({
         programV0Sub: {
-          programs: programs.map(p => p.toString())
-        }
+          programs: programs.map(p => p.toString()),
+        },
       });
 
     stream.on('readable', () => {
@@ -125,22 +124,22 @@ export class SearcherClient {
 
   // Triggers the provided callback on updates to the provided accounts.
   onAccountUpdate(
-      accounts: PublicKey[],
-      successCallback: (transactions: Transaction[]) => void,
-      errorCallback: (e: Error) => void
+    accounts: PublicKey[],
+    successCallback: (transactions: Transaction[]) => void,
+    errorCallback: (e: Error) => void
   ) {
     const stream: ClientReadableStream<PendingTxNotification> =
-        this.client.subscribeMempool({
-          wlaV0Sub: {
-            accounts: accounts.map(a => a.toString())
-          }
-        });
+      this.client.subscribeMempool({
+        wlaV0Sub: {
+          accounts: accounts.map(a => a.toString()),
+        },
+      });
 
     stream.on('readable', () => {
       successCallback(deserializeTransactions(stream.read(1).transactions));
     });
     stream.on('error', e =>
-        errorCallback(new Error(`Stream error: ${e.message}`))
+      errorCallback(new Error(`Stream error: ${e.message}`))
     );
   }
 

--- a/src/sdk/block-engine/searcher.ts
+++ b/src/sdk/block-engine/searcher.ts
@@ -115,11 +115,14 @@ export class SearcherClient {
       });
 
     stream.on('readable', () => {
-      successCallback(deserializeTransactions(stream.read(1).transactions));
+      const msg = stream.read(1);
+      if (msg) {
+        successCallback(deserializeTransactions(msg.transactions));
+      }
     });
-    stream.on('error', e =>
-      errorCallback(new Error(`Stream error: ${e.message}`))
-    );
+    stream.on('error', e => {
+      errorCallback(new Error(`Stream error: ${e.message}`));
+    });
   }
 
   // Triggers the provided callback on updates to the provided accounts.
@@ -136,11 +139,14 @@ export class SearcherClient {
       });
 
     stream.on('readable', () => {
-      successCallback(deserializeTransactions(stream.read(1).transactions));
+      const msg = stream.read(1);
+      if (msg) {
+        successCallback(deserializeTransactions(msg.transactions));
+      }
     });
-    stream.on('error', e =>
-      errorCallback(new Error(`Stream error: ${e.message}`))
-    );
+    stream.on('error', e => {
+      errorCallback(new Error(`Stream error: ${e.message}`));
+    });
   }
 
   // Subscribes to bundle results.
@@ -152,11 +158,14 @@ export class SearcherClient {
       this.client.subscribeBundleResults({});
 
     stream.on('readable', () => {
-      successCallback(stream.read(1));
+      const msg = stream.read(1);
+      if (msg) {
+        successCallback(msg);
+      }
     });
-    stream.on('error', e =>
-      errorCallback(new Error(`Stream error: ${e.message}`))
-    );
+    stream.on('error', e => {
+      errorCallback(new Error(`Stream error: ${e.message}`));
+    });
   }
 }
 

--- a/src/sdk/geyser/geyser.ts
+++ b/src/sdk/geyser/geyser.ts
@@ -47,7 +47,10 @@ export class GeyserClient {
       this.client.subscribeAccountUpdates({accounts});
 
     stream.on('readable', () => {
-      successCallback(stream.read(1));
+      const msg = stream.read(1);
+      if (msg) {
+        successCallback(msg);
+      }
     });
     stream.on('error', e =>
       errorCallback(new Error(`Stream error: ${e.message}`))
@@ -65,7 +68,10 @@ export class GeyserClient {
       this.client.subscribeProgramUpdates({programs});
 
     stream.on('readable', () => {
-      successCallback(stream.read(1));
+      const msg = stream.read(1);
+      if (msg) {
+        successCallback(msg);
+      }
     });
     stream.on('error', e =>
       errorCallback(new Error(`Stream error: ${e.message}`))
@@ -81,7 +87,10 @@ export class GeyserClient {
       this.client.subscribeBlockUpdates({});
 
     stream.on('readable', () => {
-      successCallback(stream.read(1));
+      const msg = stream.read(1);
+      if (msg) {
+        successCallback(msg);
+      }
     });
     stream.on('error', e =>
       errorCallback(new Error(`Stream error: ${e.message}`))

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -1,2 +1,3 @@
 export * from './block-engine';
 export * from './geyser';
+export * from './rpc';

--- a/src/sdk/rpc/connection.ts
+++ b/src/sdk/rpc/connection.ts
@@ -145,7 +145,7 @@ const SimulatedBundleResponseStruct = jsonRpcResultAndContext(
       pick({
         failed: pick({
           error: union([pick({}), string()]),
-          txSignature: string(),
+          tx_signature: string(),
         }),
       }),
       pick({

--- a/src/sdk/rpc/connection.ts
+++ b/src/sdk/rpc/connection.ts
@@ -408,7 +408,7 @@ export class JitoRpcConnection extends Connection {
 
     const simulationConfig: any = config || {};
     simulationConfig.transactionEncoding = 'base64';
-    const args = [encodedTransactions, simulationConfig];
+    const args = [{encodedTransactions}, simulationConfig];
     const unsafeRes = await this._rpcRequest('simulateBundle', args);
     const res = create(unsafeRes, SimulatedBundleResponseStruct);
 

--- a/src/sdk/rpc/connection.ts
+++ b/src/sdk/rpc/connection.ts
@@ -404,7 +404,7 @@ export class JitoRpcConnection extends Connection {
   }
 
   /**
-   * Simulate a transaction
+   * Simulate a bundle
    */
   async simulateBundle(
     bundle: VersionedTransaction[],

--- a/src/sdk/rpc/connection.ts
+++ b/src/sdk/rpc/connection.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   Commitment,
   Connection,

--- a/src/sdk/rpc/connection.ts
+++ b/src/sdk/rpc/connection.ts
@@ -207,14 +207,16 @@ function createRpcClient(
   const fetch = customFetch ? customFetch : fetchImpl;
   let agent: NodeHttpAgent | NodeHttpsAgent | undefined;
   if (process.env.BROWSER) {
-    if (httpAgent !== null) {
+    // eslint-disable-next-line eqeqeq
+    if (httpAgent != null) {
       console.warn(
         'You have supplied an `httpAgent` when creating a `Connection` in a browser environment.' +
           'It has been ignored; `httpAgent` is only used in Node environments.'
       );
     }
   } else {
-    if (httpAgent === null) {
+    // eslint-disable-next-line eqeqeq
+    if (httpAgent == null) {
       if (process.env.NODE_ENV !== 'test') {
         const agentOptions = {
           // One second fewer than the Solana RPC's keepalive timeout.

--- a/src/sdk/rpc/connection.ts
+++ b/src/sdk/rpc/connection.ts
@@ -340,6 +340,16 @@ function createRpcRequest(client: RpcClient): RpcRequest {
   };
 }
 
+/**
+ * The JitoRpcConnection class extends the Connection class from @solana/web3.js
+ * to provide an additional method called 'simulateBundle'.
+ *
+ * When constructing the JitoRpcConnection object, an httpAgent can be passed as
+ * part of the ConnectionConfig. If it is not provided, the constructor will
+ * internally create a separate httpAgent to be used for the 'simulateBundle' method.
+ * This means that if a httpAgent is not passed, a separate TCP connection will
+ * be used for 'simulateBundle'.
+ */
 export class JitoRpcConnection extends Connection {
   /** @internal */ _commitment?: Commitment;
   /** @internal */ _confirmTransactionInitialTimeout?: number;

--- a/src/sdk/rpc/connection.ts
+++ b/src/sdk/rpc/connection.ts
@@ -57,7 +57,7 @@ export type SimulateBundleConfig = {
     encoding: 'base64';
     addresses: string[];
   } | null)[];
-  /** list of accounts to return the pre transaction execution state for. The length of the array must be equal to the number transactions in the bundle */
+  /** list of accounts to return the post transaction execution state for. The length of the array must be equal to the number transactions in the bundle */
   postExecutionAccountsConfigs: ({
     encoding: 'base64';
     addresses: string[];

--- a/src/sdk/rpc/connection.ts
+++ b/src/sdk/rpc/connection.ts
@@ -62,7 +62,7 @@ export type SimulateBundleConfig = {
     encoding: 'base64';
     addresses: string[];
   } | null)[];
-  /** Optional parameter to specifuy the bank to run simulation against */
+  /** Optional parameter to specify the bank to run simulation against */
   simulationBank?: SimulationSlotConfig;
   /** Optional parameter used to enable signature verification before simulation */
   skipSigVerify?: boolean;

--- a/src/sdk/rpc/connection.ts
+++ b/src/sdk/rpc/connection.ts
@@ -1,0 +1,429 @@
+import {
+  Commitment,
+  Connection,
+  ConnectionConfig,
+  FetchFn,
+  FetchMiddleware,
+  HttpHeaders,
+  RpcResponseAndContext,
+  SendTransactionError,
+  SimulatedTransactionAccountInfo,
+  TransactionError,
+  TransactionReturnData,
+  VersionedTransaction,
+} from '@solana/web3.js';
+import {
+  type as pick,
+  number,
+  string,
+  array,
+  boolean,
+  literal,
+  union,
+  optional,
+  nullable,
+  coerce,
+  create,
+  tuple,
+  unknown,
+  any,
+  Struct,
+} from 'superstruct';
+import type {Agent as NodeHttpAgent} from 'http';
+import {Agent as NodeHttpsAgent} from 'https';
+import fetchImpl, {Response} from './fetch-impl';
+import HttpKeepAliveAgent, {
+  HttpsAgent as HttpsKeepAliveAgent,
+} from 'agentkeepalive';
+
+import RpcClient from 'jayson/lib/client/browser';
+import {sleep} from './utils';
+
+export type Slot = number;
+export type Tip = 'tip';
+
+/**
+ * Simulate on top of bank with the provided commitment or on the provided slot's bank or on top of the RPC's highest slot's bank i.e. the working bank.
+ */
+export type SimulationSlotConfig = Commitment | Slot | Tip;
+
+export type SimulateBundleConfig = {
+  /** list of accounts to return the pre transaction execution state for. The length of the array must be equal to the number transactions in the bundle */
+  preExecutionAccountsConfigs: ({
+    encoding: 'base64';
+    addresses: string[];
+  } | null)[];
+  /** list of accounts to return the pre transaction execution state for. The length of the array must be equal to the number transactions in the bundle */
+  postExecutionAccountsConfigs: ({
+    encoding: 'base64';
+    addresses: string[];
+  } | null)[];
+  /** Optional parameter to specifuy the bank to run simulation against */
+  simulationBank?: SimulationSlotConfig;
+  /** Optional parameter used to enable signature verification before simulation */
+  skipSigVerify?: boolean;
+  /** Optional parameter used to replace the simulated transaction's recent blockhash with the latest blockhash */
+  replaceRecentBlockhash?: boolean;
+};
+
+export type SimulatedBundleTransactionResult = {
+  err: TransactionError | string | null;
+  logs: Array<string> | null;
+  preExecutionAccounts?: SimulatedTransactionAccountInfo[] | null;
+  postExecutionAccounts?: SimulatedTransactionAccountInfo[] | null;
+  unitsConsumed?: number;
+  returnData?: TransactionReturnData | null;
+};
+
+export type BundleError = {} | string;
+
+export type BundleSimulationSummary =
+  | {
+      succeeded: null;
+    }
+  | {
+      failed: {
+        error: BundleError;
+        txSignature: string;
+      };
+    };
+
+export type SimulatedBundleResponse = {
+  summary: BundleSimulationSummary;
+  transactionResults: SimulatedBundleTransactionResult[];
+};
+
+function createRpcResult<T, U>(result: Struct<T, U>) {
+  return union([
+    pick({
+      jsonrpc: literal('2.0'),
+      id: string(),
+      result,
+    }),
+    pick({
+      jsonrpc: literal('2.0'),
+      id: string(),
+      error: pick({
+        code: unknown(),
+        message: string(),
+        data: optional(any()),
+      }),
+    }),
+  ]);
+}
+
+const UnknownRpcResult = createRpcResult(unknown());
+
+function jsonRpcResult<T, U>(schema: Struct<T, U>) {
+  return coerce(createRpcResult(schema), UnknownRpcResult, value => {
+    if ('error' in value) {
+      return value;
+    } else {
+      return {
+        ...value,
+        result: create(value.result, schema),
+      };
+    }
+  });
+}
+
+function jsonRpcResultAndContext<T, U>(value: Struct<T, U>) {
+  return jsonRpcResult(
+    pick({
+      context: pick({
+        slot: number(),
+      }),
+      value,
+    })
+  );
+}
+
+const SimulatedBundleResponseStruct = jsonRpcResultAndContext(
+  pick({
+    summary: union([
+      pick({
+        failed: pick({
+          error: union([pick({}), string()]),
+          txSignature: string(),
+        }),
+      }),
+      pick({
+        succeeded: literal(null),
+      }),
+    ]),
+    transactionResults: array(
+      pick({
+        err: nullable(union([pick({}), string()])),
+        logs: nullable(array(string())),
+        preExecutionAccounts: optional(
+          nullable(
+            array(
+              pick({
+                executable: boolean(),
+                owner: string(),
+                lamports: number(),
+                data: array(string()),
+                rentEpoch: optional(number()),
+              })
+            )
+          )
+        ),
+        postExecutionAccounts: optional(
+          nullable(
+            array(
+              pick({
+                executable: boolean(),
+                owner: string(),
+                lamports: number(),
+                data: array(string()),
+                rentEpoch: optional(number()),
+              })
+            )
+          )
+        ),
+        unitsConsumed: optional(number()),
+        returnData: optional(
+          nullable(
+            pick({
+              programId: string(),
+              data: tuple([string(), literal('base64')]),
+            })
+          )
+        ),
+      })
+    ),
+  })
+);
+
+function createRpcClient(
+  url: string,
+  httpHeaders?: HttpHeaders,
+  customFetch?: FetchFn,
+  fetchMiddleware?: FetchMiddleware,
+  disableRetryOnRateLimit?: boolean,
+  httpAgent?: NodeHttpAgent | NodeHttpsAgent | false
+): RpcClient {
+  const fetch = customFetch ? customFetch : fetchImpl;
+  let agent: NodeHttpAgent | NodeHttpsAgent | undefined;
+  if (process.env.BROWSER) {
+    if (httpAgent !== null) {
+      console.warn(
+        'You have supplied an `httpAgent` when creating a `Connection` in a browser environment.' +
+          'It has been ignored; `httpAgent` is only used in Node environments.'
+      );
+    }
+  } else {
+    if (httpAgent === null) {
+      if (process.env.NODE_ENV !== 'test') {
+        const agentOptions = {
+          // One second fewer than the Solana RPC's keepalive timeout.
+          // Read more: https://github.com/solana-labs/solana/issues/27859#issuecomment-1340097889
+          freeSocketTimeout: 19000,
+          keepAlive: true,
+          maxSockets: 25,
+        };
+        if (url.startsWith('https:')) {
+          agent = new HttpsKeepAliveAgent(agentOptions);
+        } else {
+          agent = new HttpKeepAliveAgent(agentOptions);
+        }
+      }
+    } else {
+      if (httpAgent !== false) {
+        const isHttps = url.startsWith('https:');
+        if (isHttps && !(httpAgent instanceof NodeHttpsAgent)) {
+          throw new Error(
+            'The endpoint `' +
+              url +
+              '` can only be paired with an `https.Agent`. You have, instead, supplied an ' +
+              '`http.Agent` through `httpAgent`.'
+          );
+        } else if (!isHttps && httpAgent instanceof NodeHttpsAgent) {
+          throw new Error(
+            'The endpoint `' +
+              url +
+              '` can only be paired with an `http.Agent`. You have, instead, supplied an ' +
+              '`https.Agent` through `httpAgent`.'
+          );
+        }
+        agent = httpAgent;
+      }
+    }
+  }
+
+  let fetchWithMiddleware: FetchFn | undefined;
+
+  if (fetchMiddleware) {
+    fetchWithMiddleware = async (info, init) => {
+      const modifiedFetchArgs = await new Promise<Parameters<FetchFn>>(
+        (resolve, reject) => {
+          try {
+            fetchMiddleware(info, init, (modifiedInfo, modifiedInit) =>
+              resolve([modifiedInfo, modifiedInit])
+            );
+          } catch (error) {
+            reject(error);
+          }
+        }
+      );
+      return await fetch(...modifiedFetchArgs);
+    };
+  }
+
+  const clientBrowser = new RpcClient(async (request, callback) => {
+    const options = {
+      method: 'POST',
+      body: request,
+      agent,
+      headers: Object.assign(
+        {
+          'Content-Type': 'application/json',
+        },
+        httpHeaders || {}
+      ),
+    };
+
+    try {
+      let too_many_requests_retries = 5;
+      let res: Response;
+      let waitTime = 500;
+      for (;;) {
+        if (fetchWithMiddleware) {
+          res = await fetchWithMiddleware(url, options);
+        } else {
+          res = await fetch(url, options);
+        }
+
+        if (res.status !== 429 /* Too many requests */) {
+          break;
+        }
+        if (disableRetryOnRateLimit === true) {
+          break;
+        }
+        too_many_requests_retries -= 1;
+        if (too_many_requests_retries === 0) {
+          break;
+        }
+        console.log(
+          `Server responded with ${res.status} ${res.statusText}.  Retrying after ${waitTime}ms delay...`
+        );
+        await sleep(waitTime);
+        waitTime *= 2;
+      }
+
+      const text = await res.text();
+      if (res.ok) {
+        callback(null, text);
+      } else {
+        callback(new Error(`${res.status} ${res.statusText}: ${text}`));
+      }
+    } catch (err) {
+      if (err instanceof Error) callback(err);
+    }
+  }, {});
+
+  return clientBrowser;
+}
+
+type RpcRequest = (methodName: string, args: Array<any>) => Promise<any>;
+
+function createRpcRequest(client: RpcClient): RpcRequest {
+  return (method, args) => {
+    return new Promise((resolve, reject) => {
+      client.request(method, args, (err: any, response: any) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(response);
+      });
+    });
+  };
+}
+
+export class JitoRpcConnection extends Connection {
+  /** @internal */ _commitment?: Commitment;
+  /** @internal */ _confirmTransactionInitialTimeout?: number;
+  /** @internal */ _rpcClient: RpcClient;
+  /** @internal */ _rpcRequest: RpcRequest;
+
+  constructor(
+    endpoint: string,
+    commitmentOrConfig?: Commitment | ConnectionConfig
+  ) {
+    super(endpoint, commitmentOrConfig);
+
+    let httpHeaders;
+    let fetch;
+    let fetchMiddleware;
+    let disableRetryOnRateLimit;
+    let httpAgent;
+    if (commitmentOrConfig && typeof commitmentOrConfig === 'string') {
+      this._commitment = commitmentOrConfig;
+    } else if (commitmentOrConfig) {
+      this._commitment = commitmentOrConfig.commitment;
+      this._confirmTransactionInitialTimeout =
+        commitmentOrConfig.confirmTransactionInitialTimeout;
+      httpHeaders = commitmentOrConfig.httpHeaders;
+      fetch = commitmentOrConfig.fetch;
+      fetchMiddleware = commitmentOrConfig.fetchMiddleware;
+      disableRetryOnRateLimit = commitmentOrConfig.disableRetryOnRateLimit;
+      httpAgent = commitmentOrConfig.httpAgent;
+    }
+
+    this._rpcClient = createRpcClient(
+      endpoint,
+      httpHeaders,
+      fetch,
+      fetchMiddleware,
+      disableRetryOnRateLimit,
+      httpAgent
+    );
+    this._rpcRequest = createRpcRequest(this._rpcClient);
+  }
+
+  /**
+   * Simulate a transaction
+   */
+  async simulateBundle(
+    bundle: VersionedTransaction[],
+    config?: SimulateBundleConfig
+  ): Promise<RpcResponseAndContext<SimulatedBundleResponse>> {
+    if (
+      config &&
+      bundle.length !== config.preExecutionAccountsConfigs.length &&
+      bundle.length !== config.postExecutionAccountsConfigs.length
+    ) {
+      throw new Error(
+        'pre/post execution account config length must match bundle length'
+      );
+    }
+
+    const encodedTransactions = bundle.map(versionedTx => {
+      return Buffer.from(versionedTx.serialize()).toString('base64');
+    });
+
+    const simulationConfig: any = config || {};
+    simulationConfig.transactionEncoding = 'base64';
+    const args = [encodedTransactions, simulationConfig];
+    const unsafeRes = await this._rpcRequest('simulateBundle', args);
+    const res = create(unsafeRes, SimulatedBundleResponseStruct);
+
+    if ('error' in res) {
+      let logs;
+      if ('data' in res.error) {
+        logs = res.error.data.logs;
+        if (logs && Array.isArray(logs)) {
+          const traceIndent = '\n    ';
+          const logTrace = traceIndent + logs.join(traceIndent);
+          console.error(res.error.message, logTrace);
+        }
+      }
+      throw new SendTransactionError(
+        'failed to simulate bundle: ' + res.error.message,
+        logs
+      );
+    }
+    return res.result;
+  }
+}

--- a/src/sdk/rpc/connection.ts
+++ b/src/sdk/rpc/connection.ts
@@ -1,3 +1,6 @@
+// most stuff copied from @solana/web3.js 1.74.0 - see direct references in the comment of each snippet
+// https://github.com/solana-labs/solana-web3.js/blob/3cd0cfd91a7fe08b9c67ac6f0d0c31c0c2ae8157/packages/library-legacy/src/connection.ts
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   Commitment,
@@ -92,6 +95,7 @@ export type SimulatedBundleResponse = {
   transactionResults: SimulatedBundleTransactionResult[];
 };
 
+// https://github.com/solana-labs/solana-web3.js/blob/3cd0cfd91a7fe08b9c67ac6f0d0c31c0c2ae8157/packages/library-legacy/src/connection.ts#L387
 function createRpcResult<T, U>(result: Struct<T, U>) {
   return union([
     pick({
@@ -111,8 +115,10 @@ function createRpcResult<T, U>(result: Struct<T, U>) {
   ]);
 }
 
+// https://github.com/solana-labs/solana-web3.js/blob/3cd0cfd91a7fe08b9c67ac6f0d0c31c0c2ae8157/packages/library-legacy/src/connection.ts#L406
 const UnknownRpcResult = createRpcResult(unknown());
 
+// https://github.com/solana-labs/solana-web3.js/blob/3cd0cfd91a7fe08b9c67ac6f0d0c31c0c2ae8157/packages/library-legacy/src/connection.ts#L411
 function jsonRpcResult<T, U>(schema: Struct<T, U>) {
   return coerce(createRpcResult(schema), UnknownRpcResult, value => {
     if ('error' in value) {
@@ -126,6 +132,7 @@ function jsonRpcResult<T, U>(schema: Struct<T, U>) {
   });
 }
 
+// https://github.com/solana-labs/solana-web3.js/blob/3cd0cfd91a7fe08b9c67ac6f0d0c31c0c2ae8157/packages/library-legacy/src/connection.ts#L427
 function jsonRpcResultAndContext<T, U>(value: Struct<T, U>) {
   return jsonRpcResult(
     pick({
@@ -192,6 +199,7 @@ const SimulatedBundleResponseStruct = jsonRpcResultAndContext(
   })
 );
 
+// https://github.com/solana-labs/solana-web3.js/blob/3cd0cfd91a7fe08b9c67ac6f0d0c31c0c2ae8157/packages/library-legacy/src/connection.ts#L1489
 function createRpcClient(
   url: string,
   httpHeaders?: HttpHeaders,
@@ -324,8 +332,10 @@ function createRpcClient(
   return clientBrowser;
 }
 
+// https://github.com/solana-labs/solana-web3.js/blob/3cd0cfd91a7fe08b9c67ac6f0d0c31c0c2ae8157/packages/library-legacy/src/connection.ts#L210
 type RpcRequest = (methodName: string, args: Array<any>) => Promise<any>;
 
+// https://github.com/solana-labs/solana-web3.js/blob/3cd0cfd91a7fe08b9c67ac6f0d0c31c0c2ae8157/packages/library-legacy/src/connection.ts#L1620
 function createRpcRequest(client: RpcClient): RpcRequest {
   return (method, args) => {
     return new Promise((resolve, reject) => {
@@ -356,6 +366,8 @@ export class JitoRpcConnection extends Connection {
   /** @internal */ _rpcClient: RpcClient;
   /** @internal */ _rpcRequest: RpcRequest;
 
+  // copied from here but removed unused fields
+  // https://github.com/solana-labs/solana-web3.js/blob/3cd0cfd91a7fe08b9c67ac6f0d0c31c0c2ae8157/packages/library-legacy/src/connection.ts#L3060
   constructor(
     endpoint: string,
     commitmentOrConfig?: Commitment | ConnectionConfig

--- a/src/sdk/rpc/connection.ts
+++ b/src/sdk/rpc/connection.ts
@@ -85,7 +85,7 @@ export type BundleSimulationSummary =
   | {
       failed: {
         error: BundleError;
-        txSignature: string;
+        tx_signature: string;
       };
     };
 

--- a/src/sdk/rpc/connection.ts
+++ b/src/sdk/rpc/connection.ts
@@ -79,9 +79,7 @@ export type SimulatedBundleTransactionResult = {
 export type BundleError = {} | string;
 
 export type BundleSimulationSummary =
-  | {
-      succeeded: null;
-    }
+  | 'succeeded'
   | {
       failed: {
         error: BundleError;
@@ -148,9 +146,7 @@ const SimulatedBundleResponseStruct = jsonRpcResultAndContext(
           tx_signature: string(),
         }),
       }),
-      pick({
-        succeeded: literal(null),
-      }),
+      literal('succeeded'),
     ]),
     transactionResults: array(
       pick({

--- a/src/sdk/rpc/errors.ts
+++ b/src/sdk/rpc/errors.ts
@@ -1,0 +1,9 @@
+export class SendTransactionError extends Error {
+  logs: string[] | undefined;
+
+  constructor(message: string, logs?: string[]) {
+    super(message);
+
+    this.logs = logs;
+  }
+}

--- a/src/sdk/rpc/errors.ts
+++ b/src/sdk/rpc/errors.ts
@@ -1,3 +1,5 @@
+// copied from @solana/web3.js 1.74.0
+// https://github.com/solana-labs/solana-web3.js/blob/3cd0cfd91a7fe08b9c67ac6f0d0c31c0c2ae8157/packages/library-legacy/src/errors.ts#L1
 export class SendTransactionError extends Error {
   logs: string[] | undefined;
 

--- a/src/sdk/rpc/fetch-impl.ts
+++ b/src/sdk/rpc/fetch-impl.ts
@@ -1,3 +1,5 @@
+// copied from @solana/web3.js 1.74.0
+// https://github.com/solana-labs/solana-web3.js/blob/3cd0cfd91a7fe08b9c67ac6f0d0c31c0c2ae8157/packages/library-legacy/src/fetch-impl.ts
 import * as nodeFetch from 'node-fetch';
 
 export * from 'node-fetch';

--- a/src/sdk/rpc/fetch-impl.ts
+++ b/src/sdk/rpc/fetch-impl.ts
@@ -1,0 +1,13 @@
+import * as nodeFetch from 'node-fetch';
+
+export * from 'node-fetch';
+export default async function (
+  input: nodeFetch.RequestInfo,
+  init?: nodeFetch.RequestInit
+): Promise<nodeFetch.Response> {
+  const processedInput =
+    typeof input === 'string' && input.slice(0, 2) === '//'
+      ? 'https:' + input
+      : input;
+  return await nodeFetch.default(processedInput, init);
+}

--- a/src/sdk/rpc/index.ts
+++ b/src/sdk/rpc/index.ts
@@ -1,0 +1,1 @@
+export * from './connection';

--- a/src/sdk/rpc/utils.ts
+++ b/src/sdk/rpc/utils.ts
@@ -1,0 +1,3 @@
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/src/sdk/rpc/utils.ts
+++ b/src/sdk/rpc/utils.ts
@@ -1,3 +1,5 @@
+// copied from @solana/web3.js 1.74.0
+// https://github.com/solana-labs/solana-web3.js/blob/3cd0cfd91a7fe08b9c67ac6f0d0c31c0c2ae8157/packages/library-legacy/src/utils/sleep.ts
 export function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "noEmit": false,
     "rootDir": "src",
     "outDir": "dist",
-    "resolveJsonModule": false
+    "resolveJsonModule": false,
+    "esModuleInterop": true,
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
- add simulateBundle (the code is half new structs and types for deserializing the response and the other half is just enough copy pasta from web3.js to make it work)
- change project to support esModuleInterop
- update protos gen script for esModuleInterop
- update protos to latest