### PR TITLE
fix: streams cancellation error

### DIFF
--- a/src/sdk/block-engine/searcher.ts
+++ b/src/sdk/block-engine/searcher.ts
@@ -155,7 +155,7 @@ export class SearcherClient {
       errorCallback(new Error(`Stream error: ${e.message}`));
     });
 
-    return stream.cancel;
+    return () => stream.cancel();
   }
 
   /**
@@ -228,7 +228,7 @@ export class SearcherClient {
       errorCallback(new Error(`Stream error: ${e.message}`));
     });
 
-    return stream.cancel;
+    return () => stream.cancel();
   }
 
   /**
@@ -293,7 +293,7 @@ export class SearcherClient {
       errorCallback(new Error(`Stream error: ${e.message}`));
     });
 
-    return stream.cancel;
+    return () => stream.cancel();
   }
 
   /**

--- a/src/sdk/geyser/geyser.ts
+++ b/src/sdk/geyser/geyser.ts
@@ -71,7 +71,7 @@ export class GeyserClient {
       errorCallback(new Error(`Stream error: ${e.message}`))
     );
 
-    return stream.cancel;
+    return () => stream.cancel();
   }
 
   /**
@@ -102,7 +102,7 @@ export class GeyserClient {
       errorCallback(new Error(`Stream error: ${e.message}`))
     );
 
-    return stream.cancel;
+    return () => stream.cancel();
   }
 
   /**
@@ -130,7 +130,7 @@ export class GeyserClient {
       errorCallback(new Error(`Stream error: ${e.message}`))
     );
 
-    return stream.cancel;
+    return () => stream.cancel();
   }
 }
 


### PR DESCRIPTION
Currently if you try to cancel stream you would get the following error:
```
node_modules/@grpc/grpc-js/src/call.ts:115
    this.call?.cancelWithStatus(Status.CANCELLED, 'Cancelled on client');
         ^
TypeError: Cannot read properties of undefined (reading 'call')
    at cancel (node_modules/@grpc/grpc-js/src/call.ts:115:10)
    at Timeout._onTimeout (/src/test.ts:31:3)
    at listOnTimeout (node:internal/timers:573:17)
    at process.processTimers (node:internal/timers:514:7)

Node.js v20.10.0
```

It happens because stream.cancel is not an arrow function so it loses it's `this` context.
Fix is to wrap it into arrow function to avoid `this` loosing it's context