### PR TITLE
feat: ensure block engine url has no trailing slash

### DIFF
--- a/src/examples/simple_bundle/index.ts
+++ b/src/examples/simple_bundle/index.ts
@@ -8,7 +8,7 @@ import {searcherClient} from '../../sdk/block-engine/searcher';
 import {onBundleResult, sendBundles} from './utils';
 
 const main = async () => {
-  const blockEngineUrl = process.env.BLOCK_ENGINE_URL || '';
+  const blockEngineUrl = (process.env.BLOCK_ENGINE_URL || '').replace(/\/$/, '');
   console.log('BLOCK_ENGINE_URL:', blockEngineUrl);
 
   const authKeypairPath = process.env.AUTH_KEYPAIR_PATH || '';


### PR DESCRIPTION
it's often the case when newcomers are trying to use `jito-ts` repo they run into the next issue

```sh
code: 14,
  details: 'Failed to parse DNS address dns: frankfurt.mainnet.block-engine.jito.wtf/'
```

