### PR TITLE
add npm-relevant info

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,12 @@
     "posttest": "yarn run lint",
     "run:geyser": "yarn tsc && node dist/examples/geyser/index",
     "run:simple_bundle": "yarn tsc && node dist/examples/simple_bundle/index"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jito-labs/jito-ts.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jito-labs/jito-ts/issues"
   }
 }


### PR DESCRIPTION
Hi guys,

I thought it would be nice if the npm page had a link to this repo so that people can find the source.
By adding these fields in the package.json we can do that.

Regards,

0xAlice