### PR TITLE
Fix authentication on searcherClient creation

### DIFF
--- a/src/sdk/block-engine/searcher.ts
+++ b/src/sdk/block-engine/searcher.ts
@@ -296,7 +296,6 @@ export class SearcherClient {
     }
   }
 }
-
 /**
  * Creates and returns a SearcherClient instance.
  *
@@ -311,7 +310,7 @@ export const searcherClient = (
   grpcOptions?: Partial<ChannelOptions>
 ): SearcherClient => {
   if (authKeypair) {
-    const authProvider = new AuthProvider(
+    const authProvider = AuthProvider.create(
       new AuthServiceClient(url, ChannelCredentials.createSsl()),
       authKeypair
     );


### PR DESCRIPTION
Properly auths on client creation, and auto refreshes the access token every 60 seconds