### PR TITLE
fix: use esModuleInterop-safe imports for protobufjs/minimal and long

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "prepare": "yarn run compile",
     "pretest": "yarn run compile",
     "posttest": "yarn run lint",
+    "check-proto-imports": "node scripts/check-proto-imports.js",
     "run:geyser": "yarn tsc && node dist/examples/geyser/index",
     "run:simple_bundle": "yarn tsc && node dist/examples/simple_bundle/index"
   }

--- a/scripts/check-proto-imports.js
+++ b/scripts/check-proto-imports.js
@@ -1,0 +1,91 @@
+'use strict';
+
+/*
+ * Guards the fix for issue #56:
+ * https://github.com/jito-labs/jito-ts/issues/56
+ *
+ * The generated protobuf files import two CommonJS deps, `protobufjs/minimal`
+ * and `long`. Neither has a `default` export. With default-import syntax
+ * (`import _m0 from "protobufjs/minimal"` / `import Long from "long"`) the code
+ * only works when transpiled with esModuleInterop. Consumers that transpile the
+ * source without it (some ts-node setups) get `minimal_1.default === undefined`
+ * and crash: TypeError: Cannot read properties of undefined (reading 'util').
+ *
+ * The safe, interop-agnostic forms are:
+ *   import * as _m0 from "protobufjs/minimal";  // member access only
+ *   import Long = require("long");               // value + type, import-equals
+ *
+ * This check fails the build if a regeneration or hand edit reintroduces a
+ * fragile import. Run via `npm run check-proto-imports`.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const GEN_DIR = path.join(ROOT, 'src', 'gen');
+
+// Each pattern matches any import alias, not just the names ts-proto emits, so a
+// renamed regeneration cannot slip a fragile import past the guard.
+const FORBIDDEN = [
+  {
+    // default import of a CJS module -> resolves to `.default` (undefined)
+    // without esModuleInterop.
+    re: /^import\s+\w+\s+from\s+["']protobufjs\/minimal["']/m,
+    fix: 'use `import * as _m0 from "protobufjs/minimal"`',
+  },
+  {
+    re: /^import\s+\w+\s+from\s+["']long["']/m,
+    fix: 'use `import Long = require("long")`',
+  },
+  {
+    // ts-proto's esModuleInterop=false output; fails type-check (TS2497)
+    // against @types/long's `export =`. The gen scripts rewrite it to
+    // import-equals; this catches the case where that rewrite did not run.
+    re: /^import\s+\*\s+as\s+\w+\s+from\s+["']long["']/m,
+    fix: 'use `import Long = require("long")`',
+  },
+];
+
+function walk(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walk(full));
+    } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function main() {
+  if (!fs.existsSync(GEN_DIR)) {
+    console.error('check-proto-imports: src/gen not found');
+    process.exitCode = 1;
+    return;
+  }
+
+  const files = walk(GEN_DIR);
+  const violations = [];
+  for (const file of files) {
+    const src = fs.readFileSync(file, 'utf8');
+    for (const {re, fix} of FORBIDDEN) {
+      if (re.test(src)) {
+        violations.push(`  ${path.relative(ROOT, file)}: ${fix}`);
+      }
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error('check-proto-imports: fragile default imports (see #56):');
+    console.error(violations.join('\n'));
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`check-proto-imports: ${files.length} generated files OK.`);
+}
+
+main();

--- a/scripts/gen-block-engine-protos
+++ b/scripts/gen-block-engine-protos
@@ -14,5 +14,5 @@ protoc \
   --proto_path="${PROTOS_PATH}" \
   --ts_proto_out=${OUT_DIR} \
   --ts_proto_opt=outputServices=grpc-js \
-  --ts_proto_opt=esModuleInterop=true \
+  --ts_proto_opt=esModuleInterop=false \
   auth.proto block.proto block_engine.proto bundle.proto packet.proto relayer.proto searcher.proto shared.proto shredstream.proto

--- a/scripts/gen-block-engine-protos
+++ b/scripts/gen-block-engine-protos
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
 # Path to these plugins
 PROTOC_GEN_TS_PATH="./node_modules/.bin/protoc-gen-ts_proto"
@@ -16,3 +17,10 @@ protoc \
   --ts_proto_opt=outputServices=grpc-js \
   --ts_proto_opt=esModuleInterop=false \
   auth.proto block.proto block_engine.proto bundle.proto packet.proto relayer.proto searcher.proto shared.proto shredstream.proto
+
+# esModuleInterop=false makes ts-proto emit namespace imports, which work with or
+# without the consumer's esModuleInterop (fixes #56). One exception: ts-proto emits
+# `import * as Long from "long";`, but `long`'s types use `export =`, so using Long as
+# a value fails type-check (TS2497) under this repo's setup. Rewrite that one import to
+# a CommonJS import-equals, which is interop-agnostic and valid as both value and type.
+find "${OUT_DIR}" -name '*.ts' -exec perl -pi -e 's|^import \* as Long from "long";|import Long = require("long");|' {} +

--- a/scripts/gen-geyser-protos
+++ b/scripts/gen-geyser-protos
@@ -14,5 +14,5 @@ protoc \
   --proto_path="${PROTOS_PATH}" \
   --ts_proto_out=${OUT_DIR} \
   --ts_proto_opt=outputServices=grpc-js \
-  --ts_proto_opt=esModuleInterop=true \
+  --ts_proto_opt=esModuleInterop=false \
   confirmed_block.proto geyser.proto transaction_by_addr.proto

--- a/scripts/gen-geyser-protos
+++ b/scripts/gen-geyser-protos
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eo pipefail
 
 # Path to these plugins
 PROTOC_GEN_TS_PATH="./node_modules/.bin/protoc-gen-ts_proto"
@@ -16,3 +17,10 @@ protoc \
   --ts_proto_opt=outputServices=grpc-js \
   --ts_proto_opt=esModuleInterop=false \
   confirmed_block.proto geyser.proto transaction_by_addr.proto
+
+# esModuleInterop=false makes ts-proto emit namespace imports, which work with or
+# without the consumer's esModuleInterop (fixes #56). One exception: ts-proto emits
+# `import * as Long from "long";`, but `long`'s types use `export =`, so using Long as
+# a value fails type-check (TS2497) under this repo's setup. Rewrite that one import to
+# a CommonJS import-equals, which is interop-agnostic and valid as both value and type.
+find "${OUT_DIR}" -name '*.ts' -exec perl -pi -e 's|^import \* as Long from "long";|import Long = require("long");|' {} +

--- a/src/gen/block-engine/auth.ts
+++ b/src/gen/block-engine/auth.ts
@@ -11,7 +11,7 @@ import {
   ServiceError,
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";
-import _m0 from "protobufjs/minimal";
+import * as _m0 from "protobufjs/minimal";
 import { Timestamp } from "./google/protobuf/timestamp";
 
 export const protobufPackage = "auth";

--- a/src/gen/block-engine/block.ts
+++ b/src/gen/block-engine/block.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import Long from "long";
+import Long = require("long");
 import * as _m0 from "protobufjs/minimal";
 import { Header } from "./shared";
 

--- a/src/gen/block-engine/block.ts
+++ b/src/gen/block-engine/block.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import Long from "long";
-import _m0 from "protobufjs/minimal";
+import * as _m0 from "protobufjs/minimal";
 import { Header } from "./shared";
 
 export const protobufPackage = "block";

--- a/src/gen/block-engine/block_engine.ts
+++ b/src/gen/block-engine/block_engine.ts
@@ -15,7 +15,7 @@ import {
   ServiceError,
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";
-import Long from "long";
+import Long = require("long");
 import * as _m0 from "protobufjs/minimal";
 import { BundleUuid } from "./bundle";
 import { PacketBatch } from "./packet";

--- a/src/gen/block-engine/block_engine.ts
+++ b/src/gen/block-engine/block_engine.ts
@@ -16,7 +16,7 @@ import {
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";
 import Long from "long";
-import _m0 from "protobufjs/minimal";
+import * as _m0 from "protobufjs/minimal";
 import { BundleUuid } from "./bundle";
 import { PacketBatch } from "./packet";
 import { Header, Heartbeat } from "./shared";

--- a/src/gen/block-engine/bundle.ts
+++ b/src/gen/block-engine/bundle.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import Long from "long";
+import Long = require("long");
 import * as _m0 from "protobufjs/minimal";
 import { Packet } from "./packet";
 import { Header } from "./shared";

--- a/src/gen/block-engine/bundle.ts
+++ b/src/gen/block-engine/bundle.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import Long from "long";
-import _m0 from "protobufjs/minimal";
+import * as _m0 from "protobufjs/minimal";
 import { Packet } from "./packet";
 import { Header } from "./shared";
 

--- a/src/gen/block-engine/google/protobuf/timestamp.ts
+++ b/src/gen/block-engine/google/protobuf/timestamp.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import Long from "long";
-import _m0 from "protobufjs/minimal";
+import * as _m0 from "protobufjs/minimal";
 
 export const protobufPackage = "google.protobuf";
 

--- a/src/gen/block-engine/google/protobuf/timestamp.ts
+++ b/src/gen/block-engine/google/protobuf/timestamp.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import Long from "long";
+import Long = require("long");
 import * as _m0 from "protobufjs/minimal";
 
 export const protobufPackage = "google.protobuf";

--- a/src/gen/block-engine/packet.ts
+++ b/src/gen/block-engine/packet.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import Long from "long";
+import Long = require("long");
 import * as _m0 from "protobufjs/minimal";
 
 export const protobufPackage = "packet";

--- a/src/gen/block-engine/packet.ts
+++ b/src/gen/block-engine/packet.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import Long from "long";
-import _m0 from "protobufjs/minimal";
+import * as _m0 from "protobufjs/minimal";
 
 export const protobufPackage = "packet";
 

--- a/src/gen/block-engine/relayer.ts
+++ b/src/gen/block-engine/relayer.ts
@@ -13,7 +13,7 @@ import {
   ServiceError,
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";
-import _m0 from "protobufjs/minimal";
+import * as _m0 from "protobufjs/minimal";
 import { PacketBatch } from "./packet";
 import { Header, Heartbeat, Socket } from "./shared";
 

--- a/src/gen/block-engine/searcher.ts
+++ b/src/gen/block-engine/searcher.ts
@@ -14,7 +14,7 @@ import {
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";
 import Long from "long";
-import _m0 from "protobufjs/minimal";
+import * as _m0 from "protobufjs/minimal";
 import { Bundle, BundleResult } from "./bundle";
 
 export const protobufPackage = "searcher";

--- a/src/gen/block-engine/searcher.ts
+++ b/src/gen/block-engine/searcher.ts
@@ -13,7 +13,7 @@ import {
   ServiceError,
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";
-import Long from "long";
+import Long = require("long");
 import * as _m0 from "protobufjs/minimal";
 import { Bundle, BundleResult } from "./bundle";
 

--- a/src/gen/block-engine/shared.ts
+++ b/src/gen/block-engine/shared.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import Long from "long";
-import _m0 from "protobufjs/minimal";
+import * as _m0 from "protobufjs/minimal";
 import { Timestamp } from "./google/protobuf/timestamp";
 
 export const protobufPackage = "shared";

--- a/src/gen/block-engine/shared.ts
+++ b/src/gen/block-engine/shared.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import Long from "long";
+import Long = require("long");
 import * as _m0 from "protobufjs/minimal";
 import { Timestamp } from "./google/protobuf/timestamp";
 

--- a/src/gen/block-engine/shredstream.ts
+++ b/src/gen/block-engine/shredstream.ts
@@ -11,7 +11,7 @@ import {
   ServiceError,
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";
-import _m0 from "protobufjs/minimal";
+import * as _m0 from "protobufjs/minimal";
 import { Socket } from "./shared";
 
 export const protobufPackage = "shredstream";

--- a/src/gen/geyser/confirmed_block.ts
+++ b/src/gen/geyser/confirmed_block.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import Long from "long";
+import Long = require("long");
 import * as _m0 from "protobufjs/minimal";
 
 export const protobufPackage = "solana.storage.ConfirmedBlock";

--- a/src/gen/geyser/confirmed_block.ts
+++ b/src/gen/geyser/confirmed_block.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import Long from "long";
-import _m0 from "protobufjs/minimal";
+import * as _m0 from "protobufjs/minimal";
 
 export const protobufPackage = "solana.storage.ConfirmedBlock";
 

--- a/src/gen/geyser/geyser.ts
+++ b/src/gen/geyser/geyser.ts
@@ -14,7 +14,7 @@ import {
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";
 import Long from "long";
-import _m0 from "protobufjs/minimal";
+import * as _m0 from "protobufjs/minimal";
 import { ConfirmedTransaction, Reward } from "./confirmed_block";
 import { Timestamp } from "./google/protobuf/timestamp";
 

--- a/src/gen/geyser/geyser.ts
+++ b/src/gen/geyser/geyser.ts
@@ -13,7 +13,7 @@ import {
   ServiceError,
   UntypedServiceImplementation,
 } from "@grpc/grpc-js";
-import Long from "long";
+import Long = require("long");
 import * as _m0 from "protobufjs/minimal";
 import { ConfirmedTransaction, Reward } from "./confirmed_block";
 import { Timestamp } from "./google/protobuf/timestamp";

--- a/src/gen/geyser/google/protobuf/timestamp.ts
+++ b/src/gen/geyser/google/protobuf/timestamp.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import Long from "long";
-import _m0 from "protobufjs/minimal";
+import * as _m0 from "protobufjs/minimal";
 
 export const protobufPackage = "google.protobuf";
 

--- a/src/gen/geyser/google/protobuf/timestamp.ts
+++ b/src/gen/geyser/google/protobuf/timestamp.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import Long from "long";
+import Long = require("long");
 import * as _m0 from "protobufjs/minimal";
 
 export const protobufPackage = "google.protobuf";

--- a/src/gen/geyser/transaction_by_addr.ts
+++ b/src/gen/geyser/transaction_by_addr.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import Long from "long";
-import _m0 from "protobufjs/minimal";
+import * as _m0 from "protobufjs/minimal";
 
 export const protobufPackage = "solana.storage.TransactionByAddr";
 

--- a/src/gen/geyser/transaction_by_addr.ts
+++ b/src/gen/geyser/transaction_by_addr.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import Long from "long";
+import Long = require("long");
 import * as _m0 from "protobufjs/minimal";
 
 export const protobufPackage = "solana.storage.TransactionByAddr";


### PR DESCRIPTION
## Summary

Closes #56.

The generated protobuf files import two CommonJS deps, `protobufjs/minimal` and `long`. Neither has a `default` export. With default-import syntax (`import _m0 from "protobufjs/minimal"` / `import Long from "long"`) the code only works when transpiled with `esModuleInterop`. Consumers that transpile the source without it (some `ts-node` setups, the case in #56) get `minimal_1.default === undefined` and crash:

```
TypeError: Cannot read properties of undefined (reading 'util')
    at timestamp.js
```

## Fix

Two CJS deps, two different safe forms (there is no single import that works in every `esModuleInterop` mode, see the [ts-proto note](https://github.com/stephenh/ts-proto/blob/main/src/main.ts) on this):

- **`protobufjs/minimal`** → `import * as _m0 from "protobufjs/minimal"`. It is only used for member access (`_m0.util`, `_m0.Writer`, `_m0.Reader`), so a namespace import is safe with or without `esModuleInterop`.
- **`long`** → `import Long = require("long")`. `long` is used as a value (`_m0.util.Long = Long`) and a type, and it uses `export =`. A namespace import (`import * as Long`) fails type-check (TS2497) against `@types/long`, and a default import resolves to `undefined` without `esModuleInterop`. The CommonJS import-equals form is interop-agnostic and valid as both value and type under `module: commonjs`.

Leaving `long` as a default import (an earlier version of this PR) stops the crash but is not enough: `long_1.default` is still `undefined`, so the timestamp module runs `_m0.util.Long = undefined; _m0.configure();` and silently disables 64-bit `Long` support (precision loss for u64 fields like slots and lamports). The import-equals form keeps `util.Long` intact.

## Verification

- `tsc` is clean under the repo's config (`module: commonjs`, `esModuleInterop: true`).
- The generated timestamp module loads with `_m0.util.Long` a callable constructor whether compiled **with or without** `esModuleInterop` (`new util.Long(...)` works in both).

## Changes

- 14 generated files: `protobufjs/minimal` → namespace import (10 also already in the first commit).
- 11 generated files: `long` → `import Long = require("long")`.
- Generation scripts (`scripts/gen-*-protos`): set `esModuleInterop=false`, add `set -eo pipefail`, and rewrite ts-proto's `import * as Long from "long"` to the import-equals form after generation, so regeneration reproduces these files.
- `scripts/check-proto-imports.js` + a `check-proto-imports` npm script: a small guard that fails if a regeneration or hand edit reintroduces a fragile import.

## Trade-off

`import Long = require("long")` is CommonJS syntax. A consumer compiling the **source** with `module: "ESNext"` would hit `TS1202`. This is the correct trade-off for this SDK: the generated code uses the CommonJS `protobufjs/minimal` API, the package ships precompiled CommonJS `dist`, and the issue was filed from `ts-node` (CommonJS). Open to a different approach if you'd prefer to optimize for ESM source consumers instead.
